### PR TITLE
docker version too old

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cyber_record==0.1.7
 deap==1.3.1
-docker==5.0.0
+docker==7.1.0
 networkx==2.5.1
 numpy==1.21.0
 pandas==1.2.4


### PR DESCRIPTION
Feedback from other organization's experiments shows that the docker package in python is too old, which will cause AssertionError: Instance apollo dev_ROUTE_0 is not running on some machines.
This problem can be solved by upgrading the docker version of pip to 7.0 or above.

I've reproduced the issue on my [surface laptop studio](https://github.com/linux-surface/linux-surface) and confirmed that the issue is caused by the pip docker version.

In conventional pip docker 5.0:
![881A73E0-165A-4579-84B5-19137D79EE1C_1_201_a](https://github.com/Software-Aurora-Lab/DoppelTest/assets/40066434/01fa80cd-1fd4-42c8-971c-c7f34d38369d)

After the upgrade, the error message will disappear and the system will run normally.